### PR TITLE
Support HTTP proxy in the opentok HTTP requests

### DIFF
--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -60,6 +60,15 @@ class OpenTok(object):
         self.api_key = str(api_key)
         self.api_secret = api_secret
         self.api_url = api_url
+        self._proxies = None
+
+    @property
+    def proxies(self):
+        return self._proxies
+
+    @proxies.setter
+    def proxies(self, proxies):
+        self._proxies = proxies
 
     def generate_token(self, session_id, role=Roles.publisher, expire_time=None, data=None):
         """
@@ -180,12 +189,12 @@ class OpenTok(object):
         :param String media_mode: Determines whether the session will transmit streams using the
              OpenTok Media Router (MediaMode.routed) or not (MediaMode.relayed). By default,
              the setting is MediaMode.relayed.
-             
+
              With the media_mode property set to MediaMode.relayed, the session
-             will attempt to transmit streams directly between clients. If clients cannot connect 
+             will attempt to transmit streams directly between clients. If clients cannot connect
              due to firewall restrictions, the session uses the OpenTok TURN server to relay
              audio-video streams.
-             
+
              The `OpenTok Media
              Router <https://tokbox.com/opentok/tutorials/create-session/#media-mode>`_
              provides the following benefits:
@@ -237,7 +246,7 @@ class OpenTok(object):
             options[u('location')] = location
 
         try:
-            response = requests.post(self.session_url(), data=options, headers=self.headers())
+            response = requests.post(self.session_url(), data=options, headers=self.headers(), proxies=self.proxies)
             response.encoding = 'utf-8'
 
             if response.status_code == 403:
@@ -325,7 +334,7 @@ class OpenTok(object):
                    'outputMode': output_mode.value
         }
 
-        response = requests.post(self.archive_url(), data=json.dumps(payload), headers=self.archive_headers())
+        response = requests.post(self.archive_url(), data=json.dumps(payload), headers=self.archive_headers(), proxies=self.proxies)
 
         if response.status_code < 300:
             return Archive(self, response.json())
@@ -351,7 +360,7 @@ class OpenTok(object):
 
         :rtype: The Archive object corresponding to the archive being stopped.
         """
-        response = requests.post(self.archive_url(archive_id) + '/stop', headers=self.archive_headers())
+        response = requests.post(self.archive_url(archive_id) + '/stop', headers=self.archive_headers(), proxies=self.proxies)
 
         if response.status_code < 300:
             return Archive(self, response.json())
@@ -374,7 +383,7 @@ class OpenTok(object):
 
         :param String archive_id: The archive ID of the archive to be deleted.
         """
-        response = requests.delete(self.archive_url(archive_id), headers=self.archive_headers())
+        response = requests.delete(self.archive_url(archive_id), headers=self.archive_headers(), proxies=self.proxies)
 
         if response.status_code < 300:
             pass
@@ -392,7 +401,7 @@ class OpenTok(object):
 
         :rtype: The Archive object.
         """
-        response = requests.get(self.archive_url(archive_id), headers=self.archive_headers())
+        response = requests.get(self.archive_url(archive_id), headers=self.archive_headers(), proxies=self.proxies)
 
         if response.status_code < 300:
             return Archive(self, response.json())
@@ -421,7 +430,7 @@ class OpenTok(object):
         if count is not None:
             params['count'] = count
 
-        response = requests.get(self.archive_url() + "?" + urlencode(params), headers=self.archive_headers())
+        response = requests.get(self.archive_url() + "?" + urlencode(params), headers=self.archive_headers(), proxies=self.proxies)
 
         if response.status_code < 300:
             return ArchiveList(self, response.json())

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -15,6 +15,12 @@ class OpenTokInitializationTest(unittest.TestCase):
     def test_intialization(self):
         opentok = OpenTok(self.api_key, self.api_secret)
         assert isinstance(opentok, OpenTok)
+        self.assertEquals(opentok.proxies, None)
+
+    def test_set_proxies(self):
+        opentok = OpenTok(self.api_key, self.api_secret)
+        opentok.proxies = {'https': 'https://foo.bar'}
+        self.assertEquals(opentok.proxies, {'https': 'https://foo.bar'})
 
     @raises(TypeError)
     def test_initialization_without_required_params(self):


### PR DESCRIPTION
It could happen that you need to go through an HTTP Proxy to get access to opentok endpoint.

This PR makes feasible to define an HTTP proxy while creating an Opentok client. This value will be used in every HTTP request to the opentok endpoint.