### PR TITLE
Replace BaseException with Exception

### DIFF
--- a/opentok/exceptions.py
+++ b/opentok/exceptions.py
@@ -1,4 +1,4 @@
-class OpenTokException(BaseException):
+class OpenTokException(Exception):
     """Defines exceptions thrown by the OpenTok SDK.
     """
     pass


### PR DESCRIPTION
From Python docs[0]:

> The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception).

BaseException can be a problem by code that catches Exception. I had problems with celery.

That should be backwards compatible, since Exception inherits from BaseException

[0] https://docs.python.org/2/library/exceptions.html
