### PR TITLE
Update test lib from 'sure' to 'expects'

### DIFF
--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -453,7 +453,7 @@ class OpenTok(object):
                       'iss': self.api_key,
                       'iat': int(time.time()), # current time in unix time (seconds)
                       'exp': int(time.time()) + (60*3), # 3 minutes in the future (seconds)
-                      'jti': '{:f}'.format(random.random())
+                      'jti': '{0}'.format(0, random.random())
                   }
 
         return jwt.encode(payload, self.api_secret, algorithm='HS256')

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
 nose
 httpretty
-sure
+expects
 wheel

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,7 +1,7 @@
 import unittest
 from six import text_type, u, b, PY2, PY3
 from nose.tools import raises
-from sure import expect
+from expects import *
 import httpretty
 import textwrap
 import json
@@ -58,25 +58,25 @@ class OpenTokArchiveTest(unittest.TestCase):
         archive.stop()
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(archive_id)
-        expect(archive).to.have.property(u('name')).being.equal(u(''))
-        expect(archive).to.have.property(u('status')).being.equal(u('stopped'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), archive_id))
+        expect(archive).to(have_property(u('name'), u('')))
+        expect(archive).to(have_property(u('status'), u('stopped')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('has_audio')).being.equal(True)
-        expect(archive).to.have.property(u('has_video')).being.equal(False)
-        expect(archive).to.have.property(u('output_mode')).being.equal(OutputModes.composed)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('has_audio'), True))
+        expect(archive).to(have_property(u('has_video'), False))
+        expect(archive).to(have_property(u('output_mode'), OutputModes.composed))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_delete_archive(self):
@@ -103,6 +103,6 @@ class OpenTokArchiveTest(unittest.TestCase):
         archive.delete()
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # TODO: test that the object is invalidated

--- a/tests/test_archive_api.py
+++ b/tests/test_archive_api.py
@@ -1,7 +1,7 @@
 import unittest
 from six import text_type, u, b, PY2, PY3
 from nose.tools import raises
-from sure import expect
+from expects import *
 import httpretty
 import textwrap
 import json
@@ -43,31 +43,31 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.start_archive(self.session_id)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
         if PY2:
             body = json.loads(httpretty.last_request().body)
         if PY3:
             body = json.loads(httpretty.last_request().body.decode('utf-8'))
-        expect(body).to.have.key(u('name')).being.equal(None)
-        expect(body).to.have.key(u('sessionId')).being.equal(u('SESSIONID'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9'))
-        expect(archive).to.have.property(u('name')).being.equal(u(''))
-        expect(archive).to.have.property(u('status')).being.equal(u('started'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(body).to(have_key(u('name'), None))
+        expect(body).to(have_key(u('sessionId'), u('SESSIONID')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9')))
+        expect(archive).to(have_property(u('name'), u('')))
+        expect(archive).to(have_property(u('status'), u('started')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('has_audio')).being.equal(True)
-        expect(archive).to.have.property(u('has_video')).being.equal(True)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('has_audio'), True))
+        expect(archive).to(have_property(u('has_video'), True))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_start_archive_with_name(self):
@@ -94,29 +94,29 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'))
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
         if PY2:
             body = json.loads(httpretty.last_request().body)
         if PY3:
             body = json.loads(httpretty.last_request().body.decode('utf-8'))
-        expect(body).to.have.key(u('sessionId')).being.equal(u('SESSIONID'))
-        expect(body).to.have.key(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9'))
-        expect(archive).to.have.property(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.have.property(u('status')).being.equal(u('started'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(body).to(have_key(u('sessionId'), u('SESSIONID')))
+        expect(body).to(have_key(u('name'), u('ARCHIVE NAME')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9')))
+        expect(archive).to(have_property(u('name'), ('ARCHIVE NAME')))
+        expect(archive).to(have_property(u('status'), u('started')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), equal(created_at)))
+        expect(archive).to(have_property(u('size'), equal(0)))
+        expect(archive).to(have_property(u('duration'), equal(0)))
+        expect(archive).to(have_property(u('url'), equal(None)))
 
     @httpretty.activate
     def test_start_voice_archive(self):
@@ -143,31 +143,31 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), has_video=False)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
         if PY2:
             body = json.loads(httpretty.last_request().body)
         if PY3:
             body = json.loads(httpretty.last_request().body.decode('utf-8'))
-        expect(body).to.have.key(u('sessionId')).being.equal(u('SESSIONID'))
-        expect(body).to.have.key(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9'))
-        expect(archive).to.have.property(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.have.property(u('status')).being.equal(u('started'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(body).to(have_key(u('sessionId'), u('SESSIONID')))
+        expect(body).to(have_key(u('name'), u('ARCHIVE NAME')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9')))
+        expect(archive).to(have_property(u('name'), ('ARCHIVE NAME')))
+        expect(archive).to(have_property(u('status'), u('started')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('has_audio')).being.equal(True)
-        expect(archive).to.have.property(u('has_video')).being.equal(False)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('has_audio'), True))
+        expect(archive).to(have_property(u('has_video'), False))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_start_individual_archive(self):
@@ -194,32 +194,32 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), output_mode=OutputModes.individual)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
         if PY2:
             body = json.loads(httpretty.last_request().body)
         if PY3:
             body = json.loads(httpretty.last_request().body.decode('utf-8'))
-        expect(body).to.have.key(u('sessionId')).being.equal(u('SESSIONID'))
-        expect(body).to.have.key(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9'))
-        expect(archive).to.have.property(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.have.property(u('status')).being.equal(u('started'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(body).to(have_key(u('sessionId'), u('SESSIONID')))
+        expect(body).to(have_key(u('name'), u('ARCHIVE NAME')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9')))
+        expect(archive).to(have_property(u('name'), ('ARCHIVE NAME')))
+        expect(archive).to(have_property(u('status'), u('started')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('has_audio')).being.equal(True)
-        expect(archive).to.have.property(u('has_video')).being.equal(True)
-        expect(archive).to.have.property(u('output_mode')).being.equal(OutputModes.individual)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('has_audio'), True))
+        expect(archive).to(have_property(u('has_video'), True))
+        expect(archive).to(have_property(u('output_mode'), OutputModes.individual))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_start_composed_archive(self):
@@ -246,32 +246,32 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), output_mode=OutputModes.composed)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
         if PY2:
             body = json.loads(httpretty.last_request().body)
         if PY3:
             body = json.loads(httpretty.last_request().body.decode('utf-8'))
-        expect(body).to.have.key(u('sessionId')).being.equal(u('SESSIONID'))
-        expect(body).to.have.key(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9'))
-        expect(archive).to.have.property(u('name')).being.equal(u('ARCHIVE NAME'))
-        expect(archive).to.have.property(u('status')).being.equal(u('started'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(body).to(have_key(u('sessionId'), u('SESSIONID')))
+        expect(body).to(have_key(u('name'), u('ARCHIVE NAME')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), u('30b3ebf1-ba36-4f5b-8def-6f70d9986fe9')))
+        expect(archive).to(have_property(u('name'), ('ARCHIVE NAME')))
+        expect(archive).to(have_property(u('status'), u('started')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('has_audio')).being.equal(True)
-        expect(archive).to.have.property(u('has_video')).being.equal(True)
-        expect(archive).to.have.property(u('output_mode')).being.equal(OutputModes.composed)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('has_audio'), True))
+        expect(archive).to(have_property(u('has_video'), True))
+        expect(archive).to(have_property(u('output_mode'), OutputModes.composed))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_stop_archive(self):
@@ -299,22 +299,22 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.stop_archive(archive_id)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(archive_id)
-        expect(archive).to.have.property(u('name')).being.equal(u(''))
-        expect(archive).to.have.property(u('status')).being.equal(u('stopped'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), archive_id))
+        expect(archive).to(have_property(u('name'), u('')))
+        expect(archive).to(have_property(u('status'), u('stopped')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395183243, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(0)
-        expect(archive).to.have.property(u('duration')).being.equal(0)
-        expect(archive).to.have.property(u('url')).being.equal(None)
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 0))
+        expect(archive).to(have_property(u('duration'), 0))
+        expect(archive).to(have_property(u('url'), None))
 
     @httpretty.activate
     def test_delete_archive(self):
@@ -326,8 +326,8 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         self.opentok.delete_archive(archive_id)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
 
     @httpretty.activate
     def test_find_archive(self):
@@ -355,22 +355,22 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive = self.opentok.get_archive(archive_id)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('id')).being.equal(archive_id)
-        expect(archive).to.have.property(u('name')).being.equal(u(''))
-        expect(archive).to.have.property(u('status')).being.equal(u('available'))
-        expect(archive).to.have.property(u('session_id')).being.equal(u('SESSIONID'))
-        expect(archive).to.have.property(u('partner_id')).being.equal(123456)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('id'), archive_id))
+        expect(archive).to(have_property(u('name'), u('')))
+        expect(archive).to(have_property(u('status'), u('available')))
+        expect(archive).to(have_property(u('session_id'), u('SESSIONID')))
+        expect(archive).to(have_property(u('partner_id'), 123456))
         if PY2:
             created_at = datetime.datetime.fromtimestamp(1395187836, pytz.UTC)
         if PY3:
             created_at = datetime.datetime.fromtimestamp(1395187836, datetime.timezone.utc)
-        expect(archive).to.have.property(u('created_at')).being.equal(created_at)
-        expect(archive).to.have.property(u('size')).being.equal(8347554)
-        expect(archive).to.have.property(u('duration')).being.equal(62)
-        expect(archive).to.have.property(u('url')).being.equal(u('http://tokbox.com.archive2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71%2Farchive.mp4?Expires=1395194362&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'))
+        expect(archive).to(have_property(u('created_at'), created_at))
+        expect(archive).to(have_property(u('size'), 8347554))
+        expect(archive).to(have_property(u('duration'), 62))
+        expect(archive).to(have_property(u('url'), u('http://tokbox.com.archive2.s3.amazonaws.com/123456%2Ff6e7ee58-d6cf-4a59-896b-6d56b158ec71%2Farchive.mp4?Expires=1395194362&AWSAccessKeyId=AKIAI6LQCPIXYVWCQV6Q&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')))
 
     @httpretty.activate
     def test_find_archives(self):
@@ -470,11 +470,11 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive_list = self.opentok.get_archives()
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(archive_list).to.be.an(ArchiveList)
-        expect(archive_list).to.have.property(u('count')).being.equal(6)
-        expect(list(archive_list.items)).to.have.length_of(6)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(archive_list).to(be_an(ArchiveList))
+        expect(archive_list).to(have_property(u('count'), 6))
+        expect(list(archive_list.items)).to(have_length(6))
         # TODO: we could inspect each item in the list
 
     @httpretty.activate
@@ -530,14 +530,14 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive_list = self.opentok.get_archives(offset=3)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(httpretty.last_request()).to.have.property("querystring").being.equal({
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(httpretty.last_request()).to(have_property(u('querystring'), {
             u('offset'): [u('3')]
-        })
-        expect(archive_list).to.be.an(ArchiveList)
-        expect(archive_list).to.have.property(u('count')).being.equal(6)
-        expect(list(archive_list.items)).to.have.length_of(3)
+        }))
+        expect(archive_list).to(be_an(ArchiveList))
+        expect(archive_list).to(have_property(u('count'), 6))
+        expect(list(archive_list.items)).to(have_length(3))
         # TODO: we could inspect each item in the list
 
     @httpretty.activate
@@ -580,14 +580,14 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive_list = self.opentok.get_archives(count=2)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(httpretty.last_request()).to.have.property("querystring").being.equal({
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(httpretty.last_request()).to(have_property(u('querystring'), {
             u('count'): [u('2')]
-        })
-        expect(archive_list).to.be.an(ArchiveList)
-        expect(archive_list).to.have.property(u('count')).being.equal(6)
-        expect(list(archive_list.items)).to.have.length_of(2)
+        }))
+        expect(archive_list).to(be_an(ArchiveList))
+        expect(archive_list).to(have_property(u('count'), 6))
+        expect(list(archive_list.items)).to(have_length(2))
         # TODO: we could inspect each item in the list
 
     @httpretty.activate
@@ -656,15 +656,15 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         archive_list = self.opentok.get_archives(count=4, offset=2)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
-        expect(httpretty.last_request().headers[u('content-type')]).to.equal(u('application/json'))
-        expect(httpretty.last_request()).to.have.property("querystring").being.equal({
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
+        expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
+        expect(httpretty.last_request()).to(have_property(u('querystring'), {
             u('offset'): [u('2')],
             u('count'): [u('4')]
-        })
-        expect(archive_list).to.be.an(ArchiveList)
-        expect(archive_list).to.have.property(u('count')).being.equal(6)
-        expect(list(archive_list.items)).to.have.length_of(4)
+        }))
+        expect(archive_list).to(be_an(ArchiveList))
+        expect(archive_list).to(have_property(u('count'), 6))
+        expect(list(archive_list.items)).to(have_length(4))
         # TODO: we could inspect each item in the list
 
     @httpretty.activate
@@ -691,8 +691,8 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.get_archive(archive_id)
 
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('status')).being.equal(u('paused'))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('status'), u('paused')))
 
     @httpretty.activate
     def test_find_expired_archive(self):
@@ -718,8 +718,8 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.get_archive(archive_id)
 
-        expect(archive).to.be.an(Archive)
-        expect(archive).to.have.property(u('status')).being.equal(u('expired'))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(have_property(u('status'), u('expired')))
 
     @httpretty.activate
     def test_find_archive_with_unknown_properties(self):
@@ -746,4 +746,4 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.get_archive(archive_id)
 
-        expect(archive).to.be.an(Archive)
+        expect(archive).to(be_an(Archive))

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -2,7 +2,7 @@ import unittest
 from six import text_type, u, b, PY2, PY3
 from six.moves.urllib.parse import parse_qs
 from nose.tools import raises
-from sure import expect
+from expects import *
 import httpretty
 from .validate_jwt import validate_jwt_header
 
@@ -24,14 +24,14 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session()
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('enabled')])
-        expect(body).to.have.key(b('archiveMode')).being.equal([b('manual')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.relayed)
-        expect(session).to.have.property(u('location')).being.equal(None)
+        expect(body).to(have_key(b('p2p.preference'), [b('enabled')]))
+        expect(body).to(have_key(b('archiveMode'), [b('manual')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.relayed))
+        expect(session).to(have_property(u('location'), None))
 
     @httpretty.activate
     def test_create_routed_session(self):
@@ -43,14 +43,14 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session(media_mode=MediaModes.routed)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('disabled')])
-        expect(body).to.have.key(b('archiveMode')).being.equal([b('manual')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.routed)
-        expect(session).to.have.property(u('location')).being.equal(None)
+        expect(body).to(have_key(b('p2p.preference'), [b('disabled')]))
+        expect(body).to(have_key(b('archiveMode'), [b('manual')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.routed))
+        expect(session).to(have_property(u('location'), None))
 
     @httpretty.activate
     def test_create_session_with_location_hint(self):
@@ -62,15 +62,15 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session(location='12.34.56.78')
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         # ordering of keys is non-deterministic, must parse the body to see if it is correct
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('location')).being.equal([b('12.34.56.78')])
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('enabled')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.relayed)
-        expect(session).to.have.property(u('location')).being.equal(u('12.34.56.78'))
+        expect(body).to(have_key(b('location'), [b('12.34.56.78')]))
+        expect(body).to(have_key(b('p2p.preference'), [b('enabled')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.relayed))
+        expect(session).to(have_property(u('location'), u('12.34.56.78')))
 
     @httpretty.activate
     def test_create_routed_session_with_location_hint(self):
@@ -82,15 +82,15 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session(location='12.34.56.78', media_mode=MediaModes.routed)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         # ordering of keys is non-deterministic, must parse the body to see if it is correct
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('location')).being.equal([b('12.34.56.78')])
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('disabled')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.routed)
-        expect(session).to.have.property(u('location')).being.equal(u('12.34.56.78'))
+        expect(body).to(have_key(b('location'), [b('12.34.56.78')]))
+        expect(body).to(have_key(b('p2p.preference'), [b('disabled')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.routed))
+        expect(session).to(have_property(u('location'), u('12.34.56.78')))
 
     @httpretty.activate
     def test_create_manual_archive_mode_session(self):
@@ -102,14 +102,14 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session(media_mode=MediaModes.routed, archive_mode=ArchiveModes.manual)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('disabled')])
-        expect(body).to.have.key(b('archiveMode')).being.equal([b('manual')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.routed)
-        expect(session).to.have.property(u('archive_mode')).being.equal(ArchiveModes.manual)
+        expect(body).to(have_key(b('p2p.preference'), [b('disabled')]))
+        expect(body).to(have_key(b('archiveMode'), [b('manual')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.routed))
+        expect(session).to(have_property(u('archive_mode'), ArchiveModes.manual))
 
     @httpretty.activate
     def test_create_always_archive_mode_session(self):
@@ -121,14 +121,14 @@ class OpenTokSessionCreationTest(unittest.TestCase):
         session = self.opentok.create_session(media_mode=MediaModes.routed, archive_mode=ArchiveModes.always)
 
         validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
-        expect(httpretty.last_request().headers[u('user-agent')]).to.contain(u('OpenTok-Python-SDK/')+__version__)
+        expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         body = parse_qs(httpretty.last_request().body)
-        expect(body).to.have.key(b('p2p.preference')).being.equal([b('disabled')])
-        expect(body).to.have.key(b('archiveMode')).being.equal([b('always')])
-        expect(session).to.be.a(Session)
-        expect(session).to.have.property(u('session_id')).being.equal(u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg'))
-        expect(session).to.have.property(u('media_mode')).being.equal(MediaModes.routed)
-        expect(session).to.have.property(u('archive_mode')).being.equal(ArchiveModes.always)
+        expect(body).to(have_key(b('p2p.preference'), [b('disabled')]))
+        expect(body).to(have_key(b('archiveMode'), [b('always')]))
+        expect(session).to(be_a(Session))
+        expect(session).to(have_property(u('session_id'), u('1_MX4xMjM0NTZ-fk1vbiBNYXIgMTcgMDA6NDE6MzEgUERUIDIwMTR-MC42ODM3ODk1MzQ0OTQyODA4fg')))
+        expect(session).to(have_property(u('media_mode'), MediaModes.routed))
+        expect(session).to(have_property(u('archive_mode'), ArchiveModes.always))
 
     @httpretty.activate
     def test_complains_about_always_archive_mode_and_relayed_session(self):

--- a/tests/validate_jwt.py
+++ b/tests/validate_jwt.py
@@ -1,17 +1,17 @@
 from six import u
-from sure import expect
+from expects import *
 from jose import jwt
 import time
 
 def validate_jwt_header(self, jsonwebtoken):
     claims = jwt.decode(jsonwebtoken, self.api_secret, algorithms=[u('HS256')])
-    claims.should.have.key(u('iss'))
-    expect(claims[u('iss')]).to.equal(self.api_key)
-    claims.should.have.key(u('ist'))
-    expect(claims[u('ist')]).to.equal(u('project'))
-    claims.should.have.key(u('exp'))
-    expect(float(claims[u('exp')])).to.be.greater_than(float(time.time()))
+    expect(claims).to(have_key(u('iss')))
+    expect(claims[u('iss')]).to(equal(self.api_key))
+    expect(claims).to(have_key(u('ist')))
+    expect(claims[u('ist')]).to(equal(u('project')))
+    expect(claims).to(have_key(u('exp')))
+    expect(float(claims[u('exp')])).to(be_above(float(time.time())))
     # todo: add test to check for anvil failure code if exp time is greater than anvil expects
-    claims.should.have.key(u('jti'))
-    expect(float(claims[u('jti')])).to.be.greater_than_or_equal_to(float(0))
-    expect(float(claims[u('jti')])).to.be.lower_than(float(1))
+    expect(claims).to(have_key(u('jti')))
+    expect(float(claims[u('jti')])).to(be_above_or_equal(float(0)))
+    expect(float(claims[u('jti')])).to(be_below(float(1)))


### PR DESCRIPTION
`expects` supports Python 2.6 and 3.2, which `sure` does not.

See: https://travis-ci.org/jaimegildesagredo/expects

Fixes #85.