### PR TITLE
Add sid claim for archiving calls

### DIFF
--- a/tests/test_archive_api.py
+++ b/tests/test_archive_api.py
@@ -42,7 +42,9 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.start_archive(self.session_id)
 
-        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
+        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')], {
+          u('sid'): u('SESSIONID')
+        })
         expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
@@ -93,7 +95,9 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'))
 
-        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
+        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')], {
+          u('sid'): u('SESSIONID')
+        })
         expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
@@ -142,7 +146,9 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), has_video=False)
 
-        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
+        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')], {
+          u('sid'): u('SESSIONID')
+        })
         expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
@@ -193,7 +199,9 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), output_mode=OutputModes.individual)
 
-        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
+        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')], {
+          u('sid'): u('SESSIONID')
+        })
         expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly
@@ -245,7 +253,9 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
         archive = self.opentok.start_archive(self.session_id, name=u('ARCHIVE NAME'), output_mode=OutputModes.composed)
 
-        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')])
+        validate_jwt_header(self, httpretty.last_request().headers[u('x-opentok-auth')], {
+          u('sid'): u('SESSIONID')
+        })
         expect(httpretty.last_request().headers[u('user-agent')]).to(contain(u('OpenTok-Python-SDK/')+__version__))
         expect(httpretty.last_request().headers[u('content-type')]).to(equal(u('application/json')))
         # non-deterministic json encoding. have to decode to test it properly

--- a/tests/validate_jwt.py
+++ b/tests/validate_jwt.py
@@ -3,8 +3,12 @@ from expects import *
 from jose import jwt
 import time
 
-def validate_jwt_header(self, jsonwebtoken):
+def validate_jwt_header(self, jsonwebtoken, test_claims_list=None):
     claims = jwt.decode(jsonwebtoken, self.api_secret, algorithms=[u('HS256')])
+    if test_claims_list:
+      for test_claim in test_claims_list:
+        expect(claims).to(have_key(test_claim))
+        expect(claims[test_claim]).to(equal(test_claims_list[test_claim]))
     expect(claims).to(have_key(u('iss')))
     expect(claims[u('iss')]).to(equal(self.api_key))
     expect(claims).to(have_key(u('ist')))


### PR DESCRIPTION
OpenTok archive start calls require the `sid` claim - I have fixed it and added the claim to the JWT generation for those calls.

Also added tests for this claim for archive start calls.