### PR TITLE
Fix broken image paths

### DIFF
--- a/sample/Archiving/templates/participant.html
+++ b/sample/Archiving/templates/participant.html
@@ -32,15 +32,15 @@
             <tbody>
               <tr>
                 <td style="vertical-align: middle;">Archiving is started</td>
-                <td><img src="img/archiving-on-message.png"></td>
+                <td><img src="static/img/archiving-on-message.png"></td>
               </tr>
               <tr>
                 <td style="vertical-align: middle;">Archiving remains on</td>
-                <td><img src="img/archiving-on-idle.png"></td>
+                <td><img src="static/img/archiving-on-idle.png"></td>
               </tr>
               <tr>
                 <td style="vertical-align: middle;">Archiving is stopped</td>
-                <td><img src="img/archiving-off.png"></td>
+                <td><img src="static/img/archiving-off.png"></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
There are images being linked to with src="img/XXXXX" (ex. img/archiving-off). These images are broken, should be linking to "static/img/XXXXX", so I made the change