### PR TITLE
Fix empty connection data parameter

### DIFF
--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -130,7 +130,7 @@ class OpenTok(object):
             raise OpenTokException(u('Cannot generate token, expire_time is not in the future {0}').format(expire_time))
         if expire_time > now + (60*60*24*30):  # 30 days
             raise OpenTokException(u('Cannot generate token, expire_time is not in the next 30 days {0}').format(expire_time))
-        if (data is not None) and len(data) > 1000:
+        if data and len(data) > 1000:
             raise OpenTokException(u('Cannot generate token, data must be less than 1000 characters').format(data))
 
         # decode session id to verify api_key
@@ -150,9 +150,10 @@ class OpenTok(object):
             create_time     = now,
             expire_time     = expire_time,
             role            = role.value,
-            connection_data = (data or None),
             nonce           = random.randint(0,999999)
         )
+        if data:
+            data_params['connection_data'] = data
         data_string = urlencode(data_params, True)
 
         sig = self._sign_string(data_string, self.api_secret)

--- a/tests/test_token_generation.py
+++ b/tests/test_token_generation.py
@@ -67,7 +67,7 @@ class OpenTokTokenGenerationTest(unittest.TestCase):
     def test_generate_no_data_token(self):
         token = self.opentok.generate_token(self.session_id)
         assert isinstance(token, text_type)
-        self.assertNotIn(u('connection_data'), token_decoder(token))
+        assert u('connection_data') not in token_decoder(token)
         assert token_signature_validator(token, self.api_secret)
 
     @raises(TypeError)

--- a/tests/test_token_generation.py
+++ b/tests/test_token_generation.py
@@ -64,6 +64,12 @@ class OpenTokTokenGenerationTest(unittest.TestCase):
         assert token_decoder(token)[u('connection_data')] == data
         assert token_signature_validator(token, self.api_secret)
 
+    def test_generate_no_data_token(self):
+        token = self.opentok.generate_token(self.session_id)
+        assert isinstance(token, text_type)
+        self.assertNotIn(u('connection_data'), token_decoder(token))
+        assert token_signature_validator(token, self.api_secret)
+
     @raises(TypeError)
     def test_does_not_generate_token_without_params(self):
         token = self.opentok.generate_token()


### PR DESCRIPTION
Generate token: I have made it so that the `connection_data` parameter of a token is not sent if empty (None, "" or whatever). This is in keeping with the behaviour of the other opentok SDKs.

This also avoids a bug where `connection_data` of value `None` is converted to string `"None"`. https://github.com/kennethreitz/requests/issues/378

I have also simplified the check for empty data to `if data:`
