### PR TITLE
Update PyPI classifiers since our supported versions changed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,7 +213,7 @@ Requirements
 
 You need an OpenTok API key and API secret, which you can obtain at https://dashboard.tokbox.com/
 
-The OpenTok Python SDK requires Python 2.6, 2.7, 3.2, 3.3, or 3.4
+The OpenTok Python SDK requires Python 2.6, 2.7, 3.3, 3.4, 3.5 or 3.6
 
 Release Notes
 -------------

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,10 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
 
         'Topic :: Communications',
         'Topic :: Communications :: Chat',


### PR DESCRIPTION
- Removed 3.2
- Added 3.5 and 3.6