### PR TITLE
Add test coverage for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ python:
 install:
 - pip install -r test_requirements.txt
 - pip install -r requirements.txt
-script: nosetests
+script: 
+  - nosetests --with-coverage --cover-package=opentok
+  - coveralls
 notifications:
   slack:
     secure: JHQCkY3tajvauFzD0V5A19QN/ZWNNAgt+qsYgaQTPkmhxbxeu48lOifp/jUaaf07aemOm9nFCla/PlTHemCQAe71CsjPIOLNHkXAWjLQ3RJJscIvyKCUbuzn/zZIDt774wx+xIuf5SSjFGmqZFJSyfE/bbNKo1I2EDUmRztrp7c=

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ nose
 httpretty
 expects
 wheel
+python-coveralls


### PR DESCRIPTION
I've added changes to the .travis.yml in order to support generating and sending coverage data to coveralls - as you can see [here](https://coveralls.io/github/rickymoorhouse/Opentok-Python-SDK)   

However this will also need a coveralls token obtaining by adding the main repo to coveralls.io and setting it as an environment variable in the travis configuration e.g.
![image](https://user-images.githubusercontent.com/22746/47339696-f6907900-d693-11e8-97fc-13c8d30313af.png)


For https://github.com/opentok/Opentok-Python-SDK/issues/31