### PR TITLE
fix: use env markers to avoid installing enum34 on python≥3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
+    'enum34  ; python_version < "3.4"',
     'requests',
     'six',
     'pytz',


### PR DESCRIPTION
# Problem Statement

- Opentok lib depends on enum34 package which backports enum introduced in python3.4
- `opentok/setup.py` strips out `enum34` programatically from requirements rather than using environment markers as defined in [PEP-0508](https://www.python.org/dev/peps/pep-0508/#environment-markers)
- Reproducing:
```
$ curl https://files.pythonhosted.org/packages/6a/a4/e645806a917cb666130fe0595f2bdd9964a610b297e1c2df9bbfcdeac9ea/opentok-2.10.0.tar.gz | tar -xzv
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 28369  100 28369    0     0   286k      0 --:--:-- --:--:-- --:--:--  288kx opentok-2.10.0/

x opentok-2.10.0/PKG-INFO
x opentok-2.10.0/setup.py
x opentok-2.10.0/setup.cfg
x opentok-2.10.0/opentok/
x opentok-2.10.0/opentok/version.py
x opentok-2.10.0/opentok/opentok.py
x opentok-2.10.0/opentok/session.py
x opentok-2.10.0/opentok/__init__.py
x opentok-2.10.0/opentok/archives.py
x opentok-2.10.0/opentok/stream.py
x opentok-2.10.0/opentok/sip_call.py
x opentok-2.10.0/opentok/exceptions.py
x opentok-2.10.0/opentok/broadcast.py
x opentok-2.10.0/opentok/endpoints.py
x opentok-2.10.0/opentok/streamlist.py
x opentok-2.10.0/opentok.egg-info/
x opentok-2.10.0/opentok.egg-info/PKG-INFO
x opentok-2.10.0/opentok.egg-info/SOURCES.txt
x opentok-2.10.0/opentok.egg-info/requires.txt
x opentok-2.10.0/opentok.egg-info/top_level.txt
x opentok-2.10.0/opentok.egg-info/dependency_links.txt
x opentok-2.10.0/README.rst
$ grep enum34  opentok-2.10.0/opentok.egg-info/requires.txt
enum34   # should be  'enum34  ; python_version < "3.4"'
```