### PR TITLE
Add support for `screenshareType` and ability to set layout for Archives

### DIFF
--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -477,6 +477,7 @@ class Client(object):
         name=None,
         output_mode=OutputModes.composed,
         resolution=None,
+        layout=None,
     ):
         """
         Starts archiving an OpenTok session.
@@ -508,6 +509,12 @@ class Client(object):
           or "1280x720". This parameter only applies to composed archives. If you set this
           parameter and set the output_mode parameter to OutputModes.individual, the call to the
           start_archive() method results in an error.
+        :param Dictionary 'layout' optional: Specify this to assign the initial layout type for the
+            archive. Valid values for the layout property are "bestFit", "custom",
+            "horizontalPresentation", "pip" and "verticalPresentation". If you specify a "custom"
+            layout type, set the stylesheet property of the layout object to the stylesheet.
+            If you do not specify an initial layout type, the archive uses the Best Fit
+            layout type
 
         :rtype: The Archive object, which includes properties defining the archive,
           including the archive ID.
@@ -534,6 +541,9 @@ class Client(object):
             "outputMode": output_mode.value,
             "resolution": resolution,
         }
+
+        if layout is not None:
+            payload['layout'] = layout
 
         logger.debug(
             "POST to %r with params %r, headers %r, proxies %r",

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -510,11 +510,18 @@ class Client(object):
           parameter and set the output_mode parameter to OutputModes.individual, the call to the
           start_archive() method results in an error.
         :param Dictionary 'layout' optional: Specify this to assign the initial layout type for the
-            archive. Valid values for the layout property are "bestFit", "custom",
-            "horizontalPresentation", "pip" and "verticalPresentation". If you specify a "custom"
-            layout type, set the stylesheet property of the layout object to the stylesheet.
-            If you do not specify an initial layout type, the archive uses the Best Fit
-            layout type
+            archive.
+
+            String 'type': Type of layout. Valid values for the layout property are "bestFit" (best fit),
+            "custom" (custom), "horizontalPresentation" (horizontal presentation), "pip" (picture-in-picture),
+            and "verticalPresentation" (vertical presentation)). If you specify a "custom" layout type, set
+            the stylesheet property of the layout object to the stylesheet.
+
+            String 'stylesheet' optional: Custom stylesheet to use for layout. Must set 'type' to custom,
+            and cannot use 'screenshareType'
+
+            String 'screenshareType' optional: Layout to use for screenshares. If this is set, you must
+            set 'type' to 'bestFit'
 
         :rtype: The Archive object, which includes properties defining the archive,
           including the archive ID.
@@ -908,7 +915,7 @@ class Client(object):
         else:
             raise RequestError("An unexpected error occurred", response.status_code)
 
-    def set_archive_layout(self, archive_id, layout_type, stylesheet=None):
+    def set_archive_layout(self, archive_id, layout_type, stylesheet=None, screenshare_type=None):
         """
         Use this method to change the layout of videos in an OpenTok archive
 
@@ -919,10 +926,16 @@ class Client(object):
 
         :param String stylesheet optional: CSS used to style the custom layout.
         Specify this only if you set the type property to 'custom'
+
+        :param String screenshare_type optional: Layout to use for screenshares. Must
+        set 'layout_type' to 'bestFit'
         """
         payload = {
             "type": layout_type,
         }
+
+        if screenshare_type is not None:
+            payload["screenshareType"] = screenshare_type
 
         if layout_type == "custom":
             if stylesheet is not None:
@@ -1106,11 +1119,18 @@ class Client(object):
         :param Dictionary options, with the following properties:
 
             Dictionary 'layout' optional: Specify this to assign the initial layout type for the
-            broadcast. Valid values for the layout property are "bestFit", "custom",
-            "horizontalPresentation", "pip" and "verticalPresentation". If you specify a "custom"
-            layout type, set the stylesheet property of the layout object to the stylesheet.
-            If you do not specify an initial layout type, the broadcast stream uses the Best Fit
-            layout type
+            broadcast.
+
+                String 'type': Type of layout. Valid values for the layout property are "bestFit" (best fit),
+                "custom" (custom), "horizontalPresentation" (horizontal presentation), "pip" (picture-in-picture),
+                and "verticalPresentation" (vertical presentation)). If you specify a "custom" layout type, set
+                the stylesheet property of the layout object to the stylesheet.
+
+                String 'stylesheet' optional: Custom stylesheet to use for layout. Must set 'type' to custom,
+                and cannot use 'screenshareType'
+
+                String 'screenshareType' optional: Layout to use for screenshares. If this is set, you must
+                set 'type' to 'bestFit'
 
             Integer 'maxDuration' optional: The maximum duration for the broadcast, in seconds.
             The broadcast will automatically stop when the maximum duration is reached. You can
@@ -1251,7 +1271,7 @@ class Client(object):
         else:
             raise RequestError("OpenTok server error.", response.status_code)
 
-    def set_broadcast_layout(self, broadcast_id, layout_type, stylesheet=None):
+    def set_broadcast_layout(self, broadcast_id, layout_type, stylesheet=None, screenshare_type=None):
         """
         Use this method to change the layout type of a live streaming broadcast
 
@@ -1262,10 +1282,16 @@ class Client(object):
 
         :param String stylesheet optional: CSS used to style the custom layout.
         Specify this only if you set the type property to 'custom'
+
+        :param String screenshare_type optional: Layout to use for screenshares. Must
+        set 'layout_type' to 'bestFit'
         """
         payload = {
             "type": layout_type,
         }
+
+        if screenshare_type is not None:
+            payload["screenshareType"] = screenshare_type
 
         if layout_type == "custom":
             if stylesheet is not None:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ install_requires = [
 if sys.version_info[0] < 3 or sys.version_info[1] < 4:
     install_requires.append('enum34')
 
+if sys.version_info[0] < 3:
+    install_requires.append('rsa<=4.0')
+
 setup(
     name = 'opentok',
     version = find_version('opentok', 'version.py'),

--- a/tests/test_archive_api.py
+++ b/tests/test_archive_api.py
@@ -1440,6 +1440,39 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         )
 
     @httpretty.activate
+    def test_set_archive_screenshare_type(self):
+        """ Test set archive layout functionality """
+        archive_id = u("f6e7ee58-d6cf-4a59-896b-6d56b158ec71")
+
+        httpretty.register_uri(
+            httpretty.PUT,
+            u("https://api.opentok.com/v2/project/{0}/archive/{1}/layout").format(
+                self.api_key, archive_id
+            ),
+            status=200,
+            content_type=u("application/json"),
+        )
+
+        self.opentok.set_archive_layout(archive_id, "bestFit", screenshare_type="horizontalPresentation")
+
+        validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
+        expect(httpretty.last_request().headers[u("user-agent")]).to(
+            contain(u("OpenTok-Python-SDK/") + __version__)
+        )
+        expect(httpretty.last_request().headers[u("content-type")]).to(
+            equal(u("application/json"))
+        )
+
+        if PY2:
+            body = json.loads(httpretty.last_request().body)
+        if PY3:
+            body = json.loads(httpretty.last_request().body.decode("utf-8"))
+
+        expect(body).to(have_key(u("type"), u("bestFit")))
+        expect(body).to_not(have_key(u("stylesheet")))
+        expect(body).to(have_key(u("screenshareType"), u("horizontalPresentation")))
+
+    @httpretty.activate
     def test_set_custom_archive_layout(self):
         """ Test set a custom archive layout specifying the 'stylesheet' parameter """
         archive_id = u("f6e7ee58-d6cf-4a59-896b-6d56b158ec71")

--- a/tests/test_archive_api.py
+++ b/tests/test_archive_api.py
@@ -518,6 +518,72 @@ class OpenTokArchiveApiTest(unittest.TestCase):
         expect(archive).to(have_property(u("url"), None))
 
     @httpretty.activate
+    def test_start_archive_with_layout(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            u("https://api.opentok.com/v2/project/{0}/archive").format(self.api_key),
+            body=textwrap.dedent(
+                u(
+                    """\
+                        {
+                            "createdAt" : 1395183243556,
+                            "duration" : 0,
+                            "id" : "30b3ebf1-ba36-4f5b-8def-6f70d9986fe9",
+                            "name" : "",
+                            "partnerId" : 123456,
+                            "reason" : "",
+                            "sessionId" : "SESSIONID",
+                            "size" : 0,
+                            "status" : "started",
+                            "hasAudio": true,
+                            "hasVideo": true,
+                            "outputMode": "composed",
+                            "url" : null                            
+                        }
+                    """
+                )
+            ),
+            status=200,
+            content_type=u("application/json"),
+        )
+
+        archive = self.opentok.start_archive(self.session_id, layout={"type": "pip", "screenshareType": "horizontal"})
+
+        validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
+        expect(httpretty.last_request().headers[u("user-agent")]).to(
+            contain(u("OpenTok-Python-SDK/") + __version__)
+        )
+        expect(httpretty.last_request().headers[u("content-type")]).to(
+            equal(u("application/json"))
+        )
+        # non-deterministic json encoding. have to decode to test it properly
+        if PY2:
+            body = json.loads(httpretty.last_request().body)
+        if PY3:
+            body = json.loads(httpretty.last_request().body.decode("utf-8"))
+        expect(body).to(have_key(u("sessionId"), u("SESSIONID")))
+        expect(body).to(have_key(u("name"), None))
+        expect(body).to(have_key(u("layout"), {"type": "pip", "screenshareType": "horizontal"}))
+        expect(archive).to(be_an(Archive))
+        expect(archive).to(
+            have_property(u("id"), u("30b3ebf1-ba36-4f5b-8def-6f70d9986fe9"))
+        )
+        expect(archive).to(have_property(u("name"), ("")))
+        expect(archive).to(have_property(u("status"), u("started")))
+        expect(archive).to(have_property(u("session_id"), u("SESSIONID")))
+        expect(archive).to(have_property(u("partner_id"), 123456))
+        if PY2:
+            created_at = datetime.datetime.fromtimestamp(1395183243, pytz.UTC)
+        if PY3:
+            created_at = datetime.datetime.fromtimestamp(
+                1395183243, datetime.timezone.utc
+            )
+        expect(archive).to(have_property(u("created_at"), equal(created_at)))
+        expect(archive).to(have_property(u("size"), equal(0)))
+        expect(archive).to(have_property(u("duration"), equal(0)))
+        expect(archive).to(have_property(u("url"), equal(None)))
+
+    @httpretty.activate
     def test_stop_archive(self):
         archive_id = u("30b3ebf1-ba36-4f5b-8def-6f70d9986fe9")
         httpretty.register_uri(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for `screenshareType` layout settings when starting or editing archive and broadcast layouts. As a side effect this also adds support for `layout` to the `Client.start_archive()` method.

This also cleans up some of the documentation around layouts so that developers can better understand the dict structure.

This supersedes #188 (thank you @caffodian for the base PR!)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`screeshareType` was added to the API with 2.19, so this adds support for it in the SDK.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test scripts and unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
