### PR TITLE
Updated to match Vonage release process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 3.1.0
+commit = True
+tag = False
+
+[bumpversion:file:opentok/version.py]

--- a/.github/workflows/ot.yml
+++ b/.github/workflows/ot.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,11 +16,29 @@ this project. If you use this package within your own software as is but don't p
    location on your system, which helps keep you out of dependency hell. You can exit the
    environment using `$ deactivate`.
 
-*  [tox](https://testrun.org/tox/): a testing automation tool that can load many Python versions.
-   This tool allows the project to test against all the compatible versions of Python by leveraging
-   virtualenv and describing the tasks in a metadata file.
+*  [act](https://github.com/nektos/act): a tool for running Github Actions locally. This tool allows
+   developers to easily replicate the same Continuous Integration pipelines we use for code validation.
 
 ## Tasks
+
+## Setup
+
+We currently recommend setting up a development environment using `virtualenv` and installing dependencies
+with `pip`. While the Python Packaging Authority recommends `Pipenv` to manage dependencies, `Pipenv` does
+not install the OpenTok library correctly from source at this time.
+
+We recommend setting up a Python 3.5 or higher `virtualenv` environment. This allows you to isolate dependencies
+for work on the OpenTok library without interfering with any other projects or installations on your system.
+
+    $ virtualenv env
+    $ source env/bin/activate
+    $ pip install -r requirements.txt -r test_requirements.txt
+
+Some IDEs, like Visual Studio Code, will automatically detect the `virtualenv` and use it. 
+
+When you are done, you can leave the `virtualenv` by deactivating it:
+
+    $ deactivate
 
 ### Building
 
@@ -32,10 +50,19 @@ other script in your environment, and continue to update and you make changes.
 
 ### Testing
 
-This project's tests are kicked off by tox. The `tox.ini` file describes the automation. In
-a nutshell, it selects a Python version, installs test dependencies stored in
-`test_requirements.txt`, and then runs `nosetests`. [Nose](https://nose.readthedocs.org) is the
-actual test runner. All of this can be ran using the following command: `$ tox`
+This project's tests are built using the `unittest` [`Nose'](https://nose.readthedocs.org) modules.
+To run the unit tests, install the core as well as development dependencies inside your `virtualenv`:
+
+    $ pip install -r requirements.txt -r test_requirements.txt
+
+You can manually run the test suite for your version of python with:
+
+    $ nosetests
+
+If you would like to run the test suite against a variety of Python versions, we recommend installing
+`act` and running out Github Action "test" workflow:
+
+    $ act --quiet
 
 ### Generating Documentation
 
@@ -45,19 +72,28 @@ actual test runner. All of this can be ran using the following command: `$ tox`
 
 In order to create a release, the following should be completed in order.
 
-1. Ensure all tests are passing (`tox`) and that there is enough test coverage.
+#### Prep the release
+
+1. Ensure all tests are passing (`act`) and that there is enough test coverage.
 1. Make sure you are on the `master` branch of the repository, with all changes merged/committed already.
-1. Update the version number in the source code (`opentok/version.py`) and the README. See [Versioning](#versioning) for
+1. Create a new branch named `release-x.y.z`, with the release version number
+1. Update the version number with `bumpversion`. See [Versioning](#versioning) for
    information about selecting an appropriate version number.
 1. Commit the version number change with the message ("Update to version v.x.x.x"), substituting the new version number.
+1. Create a new pull request with this branch
+
+#### Once PR is merged into `master`
+1. Make sure you are on the `master` branch of the repository
+1. Run `git pull --rebase origin master` to make sure your local code is up-to-date
 1. Create a git tag: `git tag -a vx.y.z -m "Release vx.y.z"`
+1. Run `git push origin vx.y.z` to push the tag to Github
 1. Ensure you have permission to update the `opentok` package on PyPI: <https://pypi.python.org/pypi/opentok>.
-1. Run `python setup.py sdist upload`, which will build and upload the package to PyPI.
-1. Change the version number for future development by adding "a1", then make another commit with the message
-   "Beginning development on next version".
-1. Push the changes to the main repository (`git push origin master`).
-1. Upload the `dist/opentok-x.y.z.tar.gz` file to the
-   [Github Releases](https://github.com/opentok/opentok-python-sdk/releases) page with a description and release notes.
+1. Run the deploy scripts:
+  1. `make clean`
+  1. `make dist`
+  1. `make release`
+1. Create a new release on the [Github Releases](https://github.com/opentok/opentok-python-sdk/releases) page,
+   and attach the files in `dist/` to the release
 
 ## Workflow
 
@@ -73,10 +109,6 @@ from 1.
 ### Branches
 
 *  `master` - the main development branch.
-*  `feat.foo` - feature branches. these are used for longer running tasks that cannot be accomplished in one commit.
-   once merged into master, these branches should be deleted.
-*  `vx.x.x` - if development for a future version/milestone has begun while master is working towards a sooner
-   release, this is the naming scheme for that branch. once merged into master, these branches should be deleted.
 
 ### Tags
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: clean test dist coverage install requirements release release-test
+
+clean:
+	rm -rf dist build
+
+coverage:
+	pytest -v --cov
+	coverage html
+
+test:
+	nosetests -v
+
+dist:
+	python setup.py sdist --formats zip,gztar bdist_wheel
+
+release:
+	twine upload dist/*
+
+install: requirements
+
+requirements: .requirements.txt
+
+.requirements.txt: requirements.txt
+	python -m pip install --upgrade pip setuptools
+	python -m pip install -r requirements.txt
+	python -m pip freeze > .requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -502,7 +502,7 @@ Requirements
 
 You need an OpenTok API key and API secret, which you can obtain at https://dashboard.tokbox.com/
 
-The OpenTok Python SDK requires Python 2.6, 2.7, 3.3, 3.4, 3.5 or 3.6
+The OpenTok Python SDK requires Python 3.5 or higher
 
 Release Notes
 -------------

--- a/setup.py
+++ b/setup.py
@@ -62,10 +62,11 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
 
         'Topic :: Communications',
         'Topic :: Communications :: Chat',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,5 @@ nose
 httpretty
 expects
 wheel
+twine
+bump2version

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py26,py27,py34,py35
-[testenv]
-deps = -rtest_requirements.txt
-commands =
-    nosetests []


### PR DESCRIPTION
* Added `bump2version` and `twine` development dependencies
* Added a `Makefile` to replicate what we have on the Vonage repo
* Dropped support for anything prior to Python 3.5, to match our current supported versions
* Synced the version to the current version
* Updated `DEVELOPING.md` with new build instructions