### PR TITLE
Add SIP Outbound video Flag and PlayDTMF function with API endpoints

### DIFF
--- a/.github/workflows/ot.yml
+++ b/.github/workflows/ot.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8.8, 3.9]
+        python-version: [3.6, 3.7, 3.8.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/opentok/endpoints.py
+++ b/opentok/endpoints.py
@@ -143,3 +143,27 @@ class Endpoints(object):
             + "/mute"
 
         )
+
+    def get_dtmf_all_url(self, session_id):
+        """ this method returns the url for Play DTMF to all clients in the session """
+        url = (
+            self.api_url
+            + "/v2/project/" 
+            + self.api_key
+            + "/session/"
+            + session_id
+            + "/play-dtmf"
+        )
+
+    def get_dtmf_specific_url(self, session_id, connection_id):
+        """ this method returns the url for Play DTMF to a specific client connection"""
+        url = (
+            self.api_url
+            + "/v2/project/"
+            + self.api_key
+            + "/session/"
+            + session_id
+            + "/connection/"
+            + connection_id
+            + "/play-dtmf"
+        )

--- a/opentok/exceptions.py
+++ b/opentok/exceptions.py
@@ -88,3 +88,9 @@ class BroadcastError(OpenTokException):
     """
 
     pass
+
+class DTMFError(OpenTokException):
+    """
+    Indicates that one of the properties digits, session_id or connection_id is invalid
+    """
+    pass

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1007,8 +1007,9 @@ class Client(object):
             encrypted (true) or not (false, the default)
 
             Boolean 'observeForceMute': A Boolean flag that determines whether the SIP endpoint should 
-            honor the force mute action. Defaults to False if moderator does not want to observe force
-            mute a stream and set to True if the moderator wants to observe force mute a stream.
+            honor the force mute action. The force mute action allows a moderator to force clients to 
+            mute audio in streams they publish. It defaults to False if moderator does not want to observe 
+            force mute a stream and set to True if the moderator wants to observe force mute a stream.
 
             Boolean 'video': A Boolean flag that indicates whether the SIP call will include video(true)
             or not(false, which is the default). With video included, the SIP client's video is included 

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1059,7 +1059,6 @@ class Client(object):
             observeForceMute = True
             payload["sip"]["observeForceMute"] = options["observeForceMute"]
 
-
         endpoint = self.endpoints.dial_url()
 
         logger.debug(

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1005,9 +1005,43 @@ class Client(object):
             Boolean 'secure': A Boolean flag that indicates whether the media must be transmitted
             encrypted (true) or not (false, the default)
 
-        :rtype: A SipCall object, which contains data of the SIP call: id, connectionId and streamId
+            Boolean 'observeForceMute': A Boolean flag that determines whether the SIP endpoint should 
+            honor the force mute action. Defaults to False if moderator does not want to observe force
+            mute a stream and set to True if the moderator wants to observe force mute a stream.
+
+            This is an example of what the payload POST data body could look like:
+
+            {
+                "sessionId": "Your OpenTok session ID",
+                "token": "Your valid OpenTok token",
+                "sip": {
+                        "uri": "sip:user@sip.partner.com;transport=tls",
+                        "from": "from@example.com",
+                        "headers": {
+                            "headerKey": "headerValue"
+                        },
+                    "auth": {
+                        "username": "username",
+                        "password": "password"
+                    },
+                        "secure": true|false,
+                        "observeForceMute": true|false
+                    }
+                }
+
+        :rtype: A SipCall object, which contains data of the SIP call: id, connectionId and streamId. 
+        This is what the response body should look like after returning with a status code of 200:
+
+        {
+            "id": "b0a5a8c7-dc38-459f-a48d-a7f2008da853",
+            "connectionId": "e9f8c166-6c67-440d-994a-04fb6dfed007",
+            "streamId": "482bce73-f882-40fd-8ca5-cb74ff416036",
+        }
+
+        Note: Your response will have a different: id, connectionId and streamId
         """
         payload = {"sessionId": session_id, "token": token, "sip": {"uri": sip_uri}}
+        observeForceMute = False
 
         if "from" in options:
             payload["sip"]["from"] = options["from"]
@@ -1020,6 +1054,11 @@ class Client(object):
 
         if "secure" in options:
             payload["sip"]["secure"] = options["secure"]
+
+        if "observeForceMute" in options:
+            observeForceMute = True
+            payload["sip"]["observeForceMute"] = options["observeForceMute"]
+
 
         endpoint = self.endpoints.dial_url()
 

--- a/tests/test_opentok.py
+++ b/tests/test_opentok.py
@@ -21,6 +21,7 @@ class OpenTokTest(unittest.TestCase):
         self.api_key = "123456"
         self.api_secret = "1234567890abcdef1234567890abcdef1234567890"
         self.session_id = "SESSIONID"
+        self.connection_id = "CONNECTIONID"
         self.opentok = Client(self.api_key, self.api_secret)
         token = string.ascii_letters+string.digits
         self.jwt_token_string = ''.join(random.choice(token[:100]))
@@ -72,4 +73,47 @@ class OpenTokTest(unittest.TestCase):
         response.text.should.equal("Testing body of the JSON file")
         response.headers["x-opentok-auth"].should.equal(self.jwt_token_string)
         response.headers["Content-Type"].should.equal("application/json")
+
+    @httpretty.activate
+    def test_dtmf_all_clients(self):
+        self.url = f"https://api.opentok.com/v2/project/{self.api_key}/session/{self.session_id}/play-dtmf"
+                                                                            
+        httpretty.register_uri(httpretty.POST, 
+                                        self.url, 
+                                        responses=[
+                                            httpretty.Response(body="Testing text matches inside of the JSON file", 
+                                                               content_type="application/json",
+                                                               adding_headers= {"x-opentok-auth": self.jwt_token_string},
+                                                               status=200)
+                                        ])
+
+    
+        response = requests.post(self.url)
+
+        response.status_code.should.equal(200)
+        response.text.should.equal("Testing text matches inside of the JSON file")
+        response.headers["x-opentok-auth"].should.equal(self.jwt_token_string)
+        response.headers["Content-Type"].should.equal("application/json")
+
+    @httpretty.activate
+    def test_dtmf_specific_client(self):
+        self.url = f"https://api.opentok.com/v2/project/{self.api_key}/session/{self.session_id}/connection/{self.connection_id}/play-dtmf"
+                                                                            
+        httpretty.register_uri(httpretty.POST, 
+                                        self.url, 
+                                        responses=[
+                                            httpretty.Response(body="Testing text matches inside of the JSON file", 
+                                                               content_type="application/json",
+                                                               adding_headers= {"x-opentok-auth": self.jwt_token_string},
+                                                               status=200)
+                                        ])
+
+    
+        response = requests.post(self.url)
+
+        response.status_code.should.equal(200)
+        response.text.should.equal("Testing text matches inside of the JSON file")
+        response.headers["x-opentok-auth"].should.equal(self.jwt_token_string)
+        response.headers["Content-Type"].should.equal("application/json")
+
 

--- a/tests/test_sip_call.py
+++ b/tests/test_sip_call.py
@@ -102,7 +102,8 @@ class OpenTokSipCallTest(unittest.TestCase):
             "headers": {"headerKey": "headerValue"},
             "auth": {"username": "username", "password": "password"},
             "secure": True,
-            "observeForceMute": True
+            "observeForceMute": True,
+            "video": True
         }
 
         sip_call_response = self.opentok.dial(

--- a/tests/test_sip_call.py
+++ b/tests/test_sip_call.py
@@ -102,6 +102,7 @@ class OpenTokSipCallTest(unittest.TestCase):
             "headers": {"headerKey": "headerValue"},
             "auth": {"username": "username", "password": "password"},
             "secure": True,
+            "observeForceMute": True
         }
 
         sip_call_response = self.opentok.dial(


### PR DESCRIPTION
Hi!

These changes are for the following JIRA tickets:

Add SIP Video Outbound flag to Python sDK: https://jira.vonage.com/browse/DEVX-5646
Add "Play DTMF" API to Python SDK: https://jira.vonage.com/browse/DEVX-5652