### PR TITLE
Cleanup install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,18 +28,11 @@ with codecs.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'enum34  ; python_version < "3.4"',
     'requests',
     'six',
     'pytz',
     'python-jose'
 ]
-
-if sys.version_info[0] < 3 or sys.version_info[1] < 4:
-    install_requires.append('enum34')
-
-if sys.version_info[0] < 3:
-    install_requires.append('rsa<=4.0')
 
 setup(
     name = 'opentok',


### PR DESCRIPTION
Now opentok requires Python 3.5+, these are useless dependencies