### PR TITLE
Removing deprecated class, adding HLS options, documenting previously undocumented methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,4 +155,4 @@ work with OpenTok 1.0 archives.)
 The `OpenTok.create_session()` method now includes a `media_mode` parameter, instead of a `p2p` parameter.
 
 For details, see the reference documentation at
-http://www.tokbox.com/opentok/libraries/server/python/reference/index.html.
+https://tokbox.com/developer/sdks/python/reference/.

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,19 @@ streams in the session to individual files (instead of a single composed file) b
   # Store this archive_id in the database
   archive_id = archive.id
 
+Single streams (e.g. for a new participant joining the call) can be added to an existing archive with the
+``opentok.add_archive_stream(archive_id, stream_id, has_audio=True, has_video=True)`` method.
+
+.. code:: python
+
+  opentok.add_archive_stream(archive.id, stream_id, has_audio=True, has_video=True)
+
+Similarly, single streams can be removed from an archive with the ``opentok.remove_archive_stream()`` method.
+
+.. code:: python
+
+  opentok.remove_archive_stream(archive.id, stream_id)
+
 Composed archives (output_mode=OutputModes.composed) have an optional ``resolution`` parameter.
 If no value is supplied the opentok platform will use the default resolution "640x480".
 You can set this to "1280x720" by setting the
@@ -371,7 +384,7 @@ Working with Broadcasts
 
 OpenTok broadcast lets you share live OpenTok sessions with many viewers.
 
-You can use the ``opentok.start_broadcast()`` method to start a live streaming for an OpenTok session. This broadcasts the session to an HLS (HTTP live streaming) or to RTMP streams.
+You can use the ``opentok.start_broadcast()`` method to start a live stream for an OpenTok session. This broadcasts the session to an HLS (HTTP live streaming) or to RTMP streams.
 
 To successfully start broadcasting a session, at least one client must be connected to the session.
 
@@ -465,6 +478,16 @@ You can dynamically change the layout type of a live streaming broadcast.
       'stream.instructor {position: absolute; width: 100%;  height:50%;}'
   )
 
+You can add streams to a broadcast using the ``opentok.add_broadcast_stream()`` method like this:
+
+.. code:: python
+  opentok.add_broadcast_stream(broadcast_id, stream_id)
+
+Conversely, streams can be removed from a broadcast with the ``opentok.remove_broadcast_stream()`` method.
+
+.. code:: python
+  opentok.remove_broadcast_stream(broadcast_id, stream_id)
+
 For more information about OpenTok live streaming broadcasts, see the
 `Broadcast developer guide <https://tokbox.com/developer/guides/broadcast/>`_.
 
@@ -482,6 +505,44 @@ In order to configure timeout, first create an instance:
 And then proceed to change the value with
 
 ``opentok.timeout = value``
+
+Muting streams
+-------
+
+All streams in a session can be muted with the ``opentok.mute_all()`` method:
+
+.. code:: python
+  opentok.mute_all(session_id)
+
+  # You can also specify streams to exclude (e.g. main presenter)
+  excluded_stream_ids = ['1234', '5678']
+  opentok.mute_all(session_id, excluded_stream_ids)
+
+In addition to existing streams, any streams that are published after the call to
+this method are published with audio muted. You can remove the mute state of a session
+by calling the OpenTok.disableForceMute() method.
+
+.. code:: python
+  opentok.disable_force_mute(session_id)
+
+Now, new streams that are published to the session will not be muted.
+
+A single stream can be muted with
+
+.. code:: python
+  opentok.mute_stream(session_id, stream_id)
+
+DTMF
+------
+
+Dual tone multi-frequency (DTMF) tones can be played into a session or to a specific connection.
+
+.. code:: python
+  digits = '12345'
+  opentok.play_dtmf(session_id, digits)
+
+  # To a specific connection
+  opentok.play_dtmf(session_id, connection_id, digits)
 
 Samples
 -------

--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ filter by session ID. This method returns an instance of the ``ArchiveList`` cla
 
 .. code:: python
 
-  archive_list = opentok.list_archive()
+  archive_list = opentok.list_archives()
 
   # Get a specific Archive from the list
   archive = archive_list.items[i]

--- a/README.rst
+++ b/README.rst
@@ -420,12 +420,12 @@ The live streaming broadcast can target one HLS endpoint and up to five RTMP ser
 
 You can specify the following broadcast resolutions:
 
-* 640x480 (SD landscape, default resolution)
-* 480x640 (SD portrait)
-* 1280x720 (HD landscape)
-* 720x1280 (HD portrait)
-* 1920x1080 (FHD landscape)
-* 1080x1920 (FHD portrait)
+* "640x480" (SD landscape, default resolution)
+* "480x640" (SD portrait)
+* "1280x720" (HD landscape)
+* "720x1280" (HD portrait)
+* "1920x1080" (FHD landscape)
+* "1080x1920" (FHD portrait)
 
 You can stop a started Broadcast using the ``opentok.stop_broadcast(broadcast_id)`` method.
 

--- a/README.rst
+++ b/README.rst
@@ -420,7 +420,7 @@ The live streaming broadcast can target one HLS endpoint and up to five RTMP ser
 
 You can specify the following broadcast resolutions:
 
-* [default resolution] 640x480 (SD landscape)
+* 640x480 (SD landscape, default resolution)
 * 480x640 (SD portrait)
 * 1280x720 (HD landscape)
 * 720x1280 (HD portrait)

--- a/README.rst
+++ b/README.rst
@@ -418,6 +418,15 @@ The live streaming broadcast can target one HLS endpoint and up to five RTMP ser
 
   broadcast = opentok.start_broadcast(session_id, options)
 
+You can specify the following broadcast resolutions:
+
+* [default resolution] 640x480 (SD landscape)
+* 480x640 (SD portrait)
+* 1280x720 (HD landscape)
+* 720x1280 (HD portrait)
+* 1920x1080 (FHD landscape)
+* 1080x1920 (FHD portrait)
+
 You can stop a started Broadcast using the ``opentok.stop_broadcast(broadcast_id)`` method.
 
 .. code:: python

--- a/README.rst
+++ b/README.rst
@@ -161,11 +161,20 @@ To remove a stream from an archive, use the ``opentok.remove_archive_stream()`` 
 
 Composed archives (output_mode=OutputModes.composed) have an optional ``resolution`` parameter.
 If no value is supplied, the archive will use the default resolution, "640x480".
-You can set this to "1280x720" by setting the
+You can set this to another resolution by setting the
 ``resolution`` parameter of the ``opentok.start_archive()`` method.
 
+You can specify the following archive resolutions:
+
+* "640x480" (SD landscape, default resolution)
+* "480x640" (SD portrait)
+* "1280x720" (HD landscape)
+* "720x1280" (HD portrait)
+* "1920x1080" (FHD landscape)
+* "1080x1920" (FHD portrait)
+
 Setting the ``resolution`` parameter while setting the ``output_mode`` parameter to
-OutputModes.individual, results in an error.
+``OutputModes.individual`` results in an error.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -146,25 +146,26 @@ streams in the session to individual files (instead of a single composed file) b
   # Store this archive_id in the database
   archive_id = archive.id
 
-Single streams (e.g. for a new participant joining the call) can be added to an existing archive with the
-``opentok.add_archive_stream(archive_id, stream_id, has_audio=True, has_video=True)`` method.
+To add an individual stream to an archive, use the
+``opentok.add_archive_stream(archive_id, stream_id, has_audio, has_video)`` method:
 
 .. code:: python
 
   opentok.add_archive_stream(archive.id, stream_id, has_audio=True, has_video=True)
 
-Similarly, single streams can be removed from an archive with the ``opentok.remove_archive_stream()`` method.
+To remove a stream from an archive, use the ``opentok.remove_archive_stream()`` method:
 
 .. code:: python
 
   opentok.remove_archive_stream(archive.id, stream_id)
 
 Composed archives (output_mode=OutputModes.composed) have an optional ``resolution`` parameter.
-If no value is supplied the opentok platform will use the default resolution "640x480".
+If no value is supplied, the archive will use the default resolution, "640x480".
 You can set this to "1280x720" by setting the
 ``resolution`` parameter of the ``opentok.start_archive()`` method.
 
-Warning: This value cannot be set for Individual output mode, an error will be thrown.
+Setting the ``resolution`` parameter while setting the ``output_mode`` parameter to
+OutputModes.individual, results in an error.
 
 .. code:: python
 
@@ -173,7 +174,7 @@ Warning: This value cannot be set for Individual output mode, an error will be t
   # Store this archive_id in the database
   archive_id = archive.id
 
-You can stop the recording of a started Archive using the ``opentok.stop_archive(archive_id)``
+To stop the recording of a started archive, call the ``opentok.stop_archive(archive_id)``
 method. You can also do this using the ``archive.stop()`` method of an ``Archive`` instance.
 
 .. code:: python
@@ -384,7 +385,8 @@ Working with Broadcasts
 
 OpenTok broadcast lets you share live OpenTok sessions with many viewers.
 
-You can use the ``opentok.start_broadcast()`` method to start a live stream for an OpenTok session. This broadcasts the session to an HLS (HTTP live streaming) or to RTMP streams.
+You can use the ``opentok.start_broadcast()`` method to start a live stream for an OpenTok session.
+This broadcasts the session to HLS (HTTP live streaming) or to RTMP streams.
 
 To successfully start broadcasting a session, at least one client must be connected to the session.
 
@@ -478,7 +480,7 @@ You can dynamically change the layout type of a live streaming broadcast.
       'stream.instructor {position: absolute; width: 100%;  height:50%;}'
   )
 
-You can add streams to a broadcast using the ``opentok.add_broadcast_stream()`` method like this:
+You can add streams to a broadcast using the ``opentok.add_broadcast_stream()`` method:
 
 .. code:: python
   opentok.add_broadcast_stream(broadcast_id, stream_id)
@@ -507,9 +509,9 @@ And then proceed to change the value with
 ``opentok.timeout = value``
 
 Muting streams
--------
+--------------
 
-All streams in a session can be muted with the ``opentok.mute_all()`` method:
+You can mute all streams in a session using the ``opentok.mute_all()`` method:
 
 .. code:: python
   opentok.mute_all(session_id)
@@ -520,14 +522,15 @@ All streams in a session can be muted with the ``opentok.mute_all()`` method:
 
 In addition to existing streams, any streams that are published after the call to
 this method are published with audio muted. You can remove the mute state of a session
-by calling the OpenTok.disableForceMute() method.
+by calling the ``opentok.disableForceMute()`` method:
 
 .. code:: python
   opentok.disable_force_mute(session_id)
 
-Now, new streams that are published to the session will not be muted.
+After calling the ``opentok.disableForceMute()`` method, new streams that are published
+to the session will not be muted.
 
-A single stream can be muted with
+You can mute a single stream using the ``opentok.mute_stream()`` method:
 
 .. code:: python
   opentok.mute_stream(session_id, stream_id)
@@ -535,7 +538,8 @@ A single stream can be muted with
 DTMF
 ------
 
-Dual tone multi-frequency (DTMF) tones can be played into a session or to a specific connection.
+You can send dual-tone multi-frequency (DTMF) digits to SIP endpoints. You can play DTMF tones
+to all clients connected to session or to a specific connection:
 
 .. code:: python
   digits = '12345'
@@ -556,7 +560,7 @@ repository and follow the Walkthroughs:
 Documentation
 -------------
 
-Reference documentation is available at http://www.tokbox.com/opentok/libraries/server/python/reference/index.html.
+Reference documentation is available at https://tokbox.com/developer/sdks/python/reference/.
 
 Requirements
 ------------
@@ -593,7 +597,7 @@ The Client.create_session() method now includes a media_mode parameter, instead 
 This version of the SDK includes significant improvements such as top level entity naming, where the Opentok class is now `Client`.  We also implemented a standardised logging module, improved naming conventions and JWT generation to make developer experience more rewarding.
 
 For details, see the reference documentation at
-http://www.tokbox.com/opentok/libraries/server/python/reference/index.html.
+https://tokbox.com/developer/sdks/python/reference/.
 
 Development and Contributing
 ----------------------------

--- a/opentok/__init__.py
+++ b/opentok/__init__.py
@@ -1,4 +1,4 @@
-from .opentok import OpenTok, Client, Roles, MediaModes, ArchiveModes
+from .opentok import Client, Roles, MediaModes, ArchiveModes
 from .session import Session
 from .archives import Archive, ArchiveList, OutputModes, StreamModes
 from .exceptions import (

--- a/opentok/archives.py
+++ b/opentok/archives.py
@@ -4,6 +4,8 @@ import json
 import pytz
 from enum import Enum
 
+from .exceptions import ArchiveError
+
 if PY3:
     from datetime import timezone
 

--- a/opentok/broadcast.py
+++ b/opentok/broadcast.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from six import iteritems, u
+from six import u
 
 
 class Broadcast(object):

--- a/opentok/exceptions.py
+++ b/opentok/exceptions.py
@@ -108,3 +108,10 @@ class BroadcastStreamModeError(OpenTokException):
     """
 
     pass
+
+class BroadcastHLSOptionsError(OpenTokException):
+    """
+    Indicates that HLS options have been set incorrectly. 
+    
+    dvr and lowLatency modes cannot both be set to true in a broadcast.
+    """

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -34,6 +34,7 @@ from .sip_call import SipCall
 from .broadcast import Broadcast, BroadcastStreamModes
 from .exceptions import (
     ArchiveStreamModeError,
+    BroadcastHLSOptionsError,
     BroadcastStreamModeError,
     OpenTokException,
     RequestError,
@@ -47,6 +48,7 @@ from .exceptions import (
     SetStreamClassError,
     BroadcastError,
     DTMFError
+
 )
 
 
@@ -1302,7 +1304,8 @@ class Client(object):
             If you include RTMP streaming, you can specify up to five target RTMP streams. For
             each RTMP stream, specify 'serverUrl' (the RTMP server URL), 'streamName' (the stream
             name, such as the YouTube Live stream name or the Facebook stream key), and
-            (optionally) 'id' (a unique ID for the stream)
+            (optionally) 'id' (a unique ID for the stream). You can optionally specify lowLatency or
+            DVR mode, but these options are mutually exclusive.
 
             String 'resolution' optional: The resolution of the broadcast, either "640x480"
             (SD, the default) or "1280x720" (HD)
@@ -1315,6 +1318,13 @@ class Client(object):
         :rtype A Broadcast object, which contains information of the broadcast: id, sessionId
         projectId, createdAt, updatedAt, resolution, status and broadcastUrls
         """
+
+        if options['outputs']['hls']:
+            if options['outputs']['hls']['lowLatency'] and options['outputs']['hls']['dvr']:
+                raise BroadcastHLSOptionsError(
+                    'HLS options "lowLatency" and "dvr" cannot both be set to "True".'
+                    )
+
         payload = {
                     "sessionId": session_id,
                     "streamMode": stream_mode.value

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1615,30 +1615,7 @@ class Client(object):
         }
 
         return jwt.encode(payload, self.api_secret, algorithm="HS256")
-
-
-
-class OpenTok(Client):
-    def __init__(
-        self,
-        api_key,
-        api_secret,
-        api_url="https://api.opentok.com",
-        timeout=None,
-        app_version=None,
-    ):
-        warnings.warn(
-            "OpenTok class is deprecated (Use Client class instead)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super(OpenTok, self).__init__(
-            api_key,
-            api_secret,
-            api_url=api_url,
-            timeout=timeout,
-            app_version=app_version
-        )
+        
 
     def mute_all(self,
                 session_id: str,
@@ -1755,7 +1732,7 @@ class OpenTok(Client):
         will join
 
         :param connection_id An optional parameter used to send the DTMF tones to a specific
-        connectoiin in a session.
+        connection in a session.
 
         :param digits DTMF digits to play
         Valid DTMF digits are 0-9, p, #, and * digits. 'p' represents a 500ms pause if a delay is

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1318,12 +1318,13 @@ class Client(object):
         :rtype A Broadcast object, which contains information of the broadcast: id, sessionId
         projectId, createdAt, updatedAt, resolution, status and broadcastUrls
         """
-
-        if options['outputs']['hls']:
-            if options['outputs']['hls']['lowLatency'] and options['outputs']['hls']['dvr']:
-                raise BroadcastHLSOptionsError(
-                    'HLS options "lowLatency" and "dvr" cannot both be set to "True".'
-                    )
+        
+        if 'hls' in options['outputs']:
+            if 'lowLatency' in options['outputs']['hls'] and 'dvr' in options['outputs']['hls']:
+                if options['outputs']['hls']['lowLatency'] == True and options['outputs']['hls']['dvr'] == True:
+                    raise BroadcastHLSOptionsError(
+                        'HLS options "lowLatency" and "dvr" cannot both be set to "True".'
+                        )
 
         payload = {
                     "sessionId": session_id,

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1318,7 +1318,7 @@ class Client(object):
         :rtype A Broadcast object, which contains information of the broadcast: id, sessionId
         projectId, createdAt, updatedAt, resolution, status and broadcastUrls
         """
-        
+
         if 'hls' in options['outputs']:
             if 'lowLatency' in options['outputs']['hls'] and 'dvr' in options['outputs']['hls']:
                 if options['outputs']['hls']['lowLatency'] == True and options['outputs']['hls']['dvr'] == True:
@@ -1632,7 +1632,7 @@ class Client(object):
 
         In addition to existing streams, any streams that are published after the call to
         this method are published with audio muted. You can remove the mute state of a session
-        by calling the OpenTok.disableForceMute() method.
+        by calling the OpenTok.disable_force_mute() method.
 
         :param session_id The session ID
 

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -1269,8 +1269,8 @@ class Client(object):
 
     def start_broadcast(self, session_id, options, stream_mode=BroadcastStreamModes.auto):
         """
-        Use this method to start a live streaming for an OpenTok session. This broadcasts the
-        session to an HLS (HTTP live streaming) or to RTMP streams. To successfully start
+        Use this method to start a live streaming broadcast for an OpenTok session. This broadcasts
+        the session to an HLS (HTTP live streaming) or to RTMP streams. To successfully start
         broadcasting a session, at least one client must be connected to the session. You can only
         start live streaming for sessions that use the OpenTok Media Router (with the media mode set
         to routed); you cannot use live streaming with sessions that have the media mode set to

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -700,7 +700,7 @@ class Client(object):
         else:
             raise RequestError("An unexpected error occurred", response.status_code)
 
-    def get_archives(self, offset=None, count=None, session_id=None):
+    def list_archives(self, offset=None, count=None, session_id=None):
         """Returns an ArchiveList, which is an array of archives that are completed and in-progress,
         for your API key.
 
@@ -745,13 +745,6 @@ class Client(object):
             raise NotFoundError("Archive not found")
         else:
             raise RequestError("An unexpected error occurred", response.status_code)
-
-    def list_archives(self, offset=None, count=None, session_id=None):
-        """
-        New method to get archive list, it's alternative to 'get_archives()',
-        both methods exist to have backwards compatible
-        """
-        return self.get_archives(offset, count, session_id)
 
     def add_archive_stream(
         self,

--- a/tests/test_archive_api.py
+++ b/tests/test_archive_api.py
@@ -835,7 +835,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives()
+        archive_list = self.opentok.list_archives()
 
         validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
         expect(httpretty.last_request().headers[u("user-agent")]).to(
@@ -907,7 +907,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives(offset=3)
+        archive_list = self.opentok.list_archives(offset=3)
 
         validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
         expect(httpretty.last_request().headers[u("user-agent")]).to(
@@ -969,7 +969,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives(count=2)
+        archive_list = self.opentok.list_archives(count=2)
 
         validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
         expect(httpretty.last_request().headers[u("user-agent")]).to(
@@ -1057,7 +1057,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives(count=4, offset=2)
+        archive_list = self.opentok.list_archives(count=4, offset=2)
 
         validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
         expect(httpretty.last_request().headers[u("user-agent")]).to(
@@ -1078,7 +1078,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
     @httpretty.activate
     def test_find_archives_with_sessionid(self):
-        """ Test get_archives method using session_id parameter """
+        """ Test list_archives method using session_id parameter """
         httpretty.register_uri(
             httpretty.GET,
             u("https://api.opentok.com/v2/project/{0}/archive").format(self.api_key),
@@ -1148,7 +1148,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives(session_id="SESSIONID")
+        archive_list = self.opentok.list_archives(session_id="SESSIONID")
 
         validate_jwt_header(self, httpretty.last_request().headers[u("x-opentok-auth")])
         expect(httpretty.last_request().headers[u("user-agent")]).to(
@@ -1166,7 +1166,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
 
     @httpretty.activate
     def test_find_archives_with_offset_count_sessionId(self):
-        """ Test get_archives method using all parameters: offset, count and sessionId """
+        """ Test list_archives method using all parameters: offset, count and sessionId """
         httpretty.register_uri(
             httpretty.GET,
             u("https://api.opentok.com/v2/project/{0}/archive").format(self.api_key),
@@ -1210,7 +1210,7 @@ class OpenTokArchiveApiTest(unittest.TestCase):
             content_type=u("application/json"),
         )
 
-        archive_list = self.opentok.get_archives(
+        archive_list = self.opentok.list_archives(
             offset=2, count=2, session_id="SESSIONID"
         )
 

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -8,6 +8,7 @@ from sure import expect
 from six import u, PY2, PY3
 from expects import *
 from opentok import Client, Broadcast, __version__, BroadcastError
+from opentok.exceptions import BroadcastHLSOptionsError
 from .validate_jwt import validate_jwt_header
 
 
@@ -653,3 +654,38 @@ class OpenTokBroadcastTest(unittest.TestCase):
             broadcast_id,
             "horizontalPresentation",
         )
+
+    def test_broadcast_hls_mutually_exclusive_options_error(self):
+        """
+        Test invalid options in start_broadcast() method raises a BroadcastHLSOptionsError.
+        """
+        
+        options = {
+            "layout": {
+                "type": "custom",
+                "stylesheet": "the layout stylesheet (only used with type == custom)",
+            },
+            "maxDuration": 5400,
+            "outputs": {
+                "hls": {
+                    "lowLatency": True,
+                    "dvr": True
+                    },
+                "rtmp": [
+                    {
+                        "id": "foo",
+                        "serverUrl": "rtmp://myfooserver/myfooapp",
+                        "streamName": "myfoostream",
+                    },
+                    {
+                        "id": "bar",
+                        "serverUrl": "rtmp://mybarserver/mybarapp",
+                        "streamName": "mybarstream",
+                    },
+                ],
+            },
+            "resolution": "640x480",
+        }
+
+        with self.assertRaises(BroadcastHLSOptionsError):
+            self.opentok.start_broadcast(self.session_id, options)

--- a/tests/test_custom_jwt_claims.py
+++ b/tests/test_custom_jwt_claims.py
@@ -3,7 +3,7 @@ from six import text_type, u, b, PY2, PY3
 from nose.tools import raises
 from expects import *
 
-from opentok import OpenTok, __version__
+from opentok import Client, __version__
 import time
 from jose import jwt
 
@@ -15,7 +15,7 @@ class JwtCustomClaimsTest(unittest.TestCase):
         self.session_id = u(
             "1_MX4xMjM0NTZ-flNhdCBNYXIgMTUgMTQ6NDI6MjMgUERUIDIwMTR-MC40OTAxMzAyNX4"
         )
-        self.opentok = OpenTok(self.api_key, self.api_secret)
+        self.opentok = Client(self.api_key, self.api_secret)
 
     def test_livetime_custom_claim(self):
         self.opentok.jwt_livetime = 5  # Token will expire 5 minutes in the future

--- a/tests/test_opentok.py
+++ b/tests/test_opentok.py
@@ -10,11 +10,7 @@ from sure import expect
 import random
 import string
 
-import json
-
-import opentok
-from opentok import Client, OpenTok
-
+from opentok import Client
 
 class OpenTokTest(unittest.TestCase):  
     def setUp(self):


### PR DESCRIPTION
- Removed the deprecated `OpenTok` class and added the methods attached to it to the `Client` class. 
- Added HLS option support, a new test for the error case where `lowLatency` and `dvr` modes are simultaneously selected, and added a new custom exception. 
- Documented methods that were previously undocumented in the readme.

When this is merged I will release a new minor version.