### PR TITLE
Add jwt generation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.2
+current_version = 3.10.0
 commit = True
 tag = True
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Release 3.10.0
+- Add new `max_bitrate` option for archives
+- Change to create JWTs by default in the `Client.generate_token` method. T1 tokens can still be created.
+
 # Release 3.9.2
 - Migrate from using `python-jose` with native-python cryptographic backend to the `pyjwt` package
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release 3.10.0
 - Add new `max_bitrate` option for archives
-- Change to create JWTs by default in the `Client.generate_token` method. T1 tokens can still be created.
+- Change to create JWTs by default in the `Client.generate_token` method. T1 tokens can still be created by setting `use_jwt=False` when generating a token.
 
 # Release 3.9.2
 - Migrate from using `python-jose` with native-python cryptographic backend to the `pyjwt` package

--- a/opentok/opentok.py
+++ b/opentok/opentok.py
@@ -325,7 +325,7 @@ class Client(object):
 
             token = encode(payload, self.api_secret, algorithm="HS256", headers=headers)
 
-            return f'Bearer {token}'
+            return token
 
         data_params = dict(
             session_id=session_id,
@@ -349,6 +349,7 @@ class Client(object):
             sentinal=self.TOKEN_SENTINEL,
             base64_data=base64.b64encode(decoded_base64_bytes).decode(),
         )
+
         return token
 
     def create_session(

--- a/opentok/version.py
+++ b/opentok/version.py
@@ -1,3 +1,3 @@
 # see: http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers
-__version__ = "3.9.2"
+__version__ = "3.10.0"
 

--- a/sample/HelloWorld/helloworld.py
+++ b/sample/HelloWorld/helloworld.py
@@ -17,10 +17,8 @@ session = opentok.create_session()
 def hello():
     key = api_key
     session_id = session.session_id
-    token = opentok.generate_token(session_id)
-    return render_template(
-        "index.html", api_key=key, session_id=session_id, token=token
-    )
+    token = opentok.generate_token(session_id, use_jwt=True)
+    return render_template("index.html", api_key=key, session_id=session_id, token=token)
 
 
 if __name__ == "__main__":

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,26 +1,32 @@
-from six import text_type, u, b, PY3
+from six import u, PY3
 from six.moves.urllib.parse import parse_qs
 import base64
 import hmac
 import hashlib
+from jwt import decode
 
 
-def token_decoder(token):
+def token_decoder(token: str, secret: str = None):
     token_data = {}
-    # remove sentinal
-    encoded = token[4:]
-    decoded = base64.b64decode(encoded.encode("utf-8"))
-    # decode the bytes object back to unicode with utf-8 encoding
-    if PY3:
-        decoded = decoded.decode()
-    parts = decoded.split(u(":"))
-    for decoded_part in iter(parts):
-        token_data.update(parse_qs(decoded_part))
-    # TODO: probably a more elegent way
-    for k in iter(token_data):
-        token_data[k] = token_data[k][0]
-    token_data[u("data_string")] = parts[1]
-    return token_data
+    if token.startswith("T1=="):
+        encoded = token[4:]
+
+        # decode the token from base64
+        decoded = base64.b64decode(encoded.encode("utf-8"))
+        # decode the bytes object back to unicode with utf-8 encoding
+        if PY3:
+            decoded = decoded.decode()
+        parts = decoded.split(u(":"))
+        for decoded_part in iter(parts):
+            token_data.update(parse_qs(decoded_part))
+        # TODO: probably a more elegant way
+        for k in iter(token_data):
+            token_data[k] = token_data[k][0]
+        token_data[u("data_string")] = parts[1]
+        return token_data
+
+    encoded = token.replace('Bearer ', '').strip()
+    return decode(encoded, secret, algorithms='HS256')
 
 
 def token_signature_validator(token, secret):

--- a/tests/test_http_options.py
+++ b/tests/test_http_options.py
@@ -27,6 +27,7 @@ class OpenTokSessionCreationTest(unittest.TestCase):
     def tearDown(self):
         httpretty.disable()
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_timeout(self):
         with pytest.raises(OpenTokException):
             opentok = Client(self.api_key, self.api_secret, timeout=1)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,8 +1,8 @@
 import unittest
-from six import text_type, u, b, PY2, PY3
+from six import text_type, u
 
 from opentok import Client, Session, Roles, MediaModes
-from .helpers import token_decoder, token_signature_validator
+from .helpers import token_decoder
 
 
 class SessionTest(unittest.TestCase):
@@ -20,8 +20,7 @@ class SessionTest(unittest.TestCase):
         )
         token = session.generate_token()
         assert isinstance(token, text_type)
-        assert token_decoder(token)[u("session_id")] == self.session_id
-        assert token_signature_validator(token, self.api_secret)
+        assert token_decoder(token, self.api_secret)[u("session_id")] == self.session_id
 
     def test_generate_role_token(self):
         session = Session(
@@ -29,6 +28,5 @@ class SessionTest(unittest.TestCase):
         )
         token = session.generate_token(role=Roles.moderator)
         assert isinstance(token, text_type)
-        assert token_decoder(token)[u("session_id")] == self.session_id
-        assert token_decoder(token)[u("role")] == u("moderator")
-        assert token_signature_validator(token, self.api_secret)
+        assert token_decoder(token, self.api_secret)[u("session_id")] == self.session_id
+        assert token_decoder(token, self.api_secret)[u("role")] == u("moderator")


### PR DESCRIPTION
- Add new `max_bitrate` option for archives
- Change to create JWTs by default in the `Client.generate_token` method. T1 tokens can still be created by setting `use_jwt=False` when generating a token.
